### PR TITLE
Add support for Ruban

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -122,6 +122,15 @@ the options available for such profiles.
 |skipFragments|If `true`, fragments will be ignored, otherwise each fragment will generate an individual slide|false|`deck2pdf --skipFragments=true revealjs.html`
 |=======================================================================
 
+=== ruban
+
+[cols="1,3,1,1",options="header,footer"]
+|=======================================================================
+|Option|Behavior|Default|Example
+|skipSteps|If `true`, instead of generating one PDF page per step, generates one PDF slide per section, with the last step of each section.|false|`deck2pdf --skipSteps=true index.html`
+|=======================================================================
+
+
 [[CustomProfiles]]
 == Support for other HTML5 slideshows
 

--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ By default, deck2pdf assumes that you are using deck.js, but there more profiles
 * googlehtml5, for http://code.google.com/p/html5slides/[Google html5slides]
 * spf, for https://github.com/briancavalier/slides[Slide Presentation Framework]
 * remarkjs, for https://github.com/gnab/remark[remark.js]
-* ruban, for https://github.com/loicfrering/ruban[ruban]. Note that the ruban profile expects to find the Ruban object in the global variable `ruban`.
+* ruban, for https://github.com/loicfrering/ruban[ruban]. Note that the ruban profile expects to find the Ruban object in the global variable `ruban`. The minimum version of Ruban is 0.3.2.
 
 For example, to convert a Deck.js slidedeck into PDF:
 

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,8 @@
  http://lab.hakim.se/reveal-js[reveal.js], http://bartaz.github.io/impress.js[impress.js],
  http://flowtime-js.marcolago.com/[Flowtime.js],
  http://code.google.com/p/html5slides/[Google html5slides],
- https://github.com/briancavalier/slides[Slide Presentation Framework]
+ https://github.com/briancavalier/slides[Slide Presentation Framework],
+ https://github.com/loicfrering/ruban[ruban]
   or https://github.com/paulrouget/dzslides[DZSlides] slide deck into a PDF file. Deck2PDF is also capable
   of handling other HTML5 libraries as long as you feed it <<CustomProfiles,with a profile>>.
 
@@ -65,6 +66,7 @@ By default, deck2pdf assumes that you are using deck.js, but there more profiles
 * googlehtml5, for http://code.google.com/p/html5slides/[Google html5slides]
 * spf, for https://github.com/briancavalier/slides[Slide Presentation Framework]
 * remarkjs, for https://github.com/gnab/remark[remark.js]
+* ruban, for https://github.com/loicfrering/ruban[ruban]. Note that the ruban profile expects to find the Ruban object in the global variable `ruban`.
 
 For example, to convert a Deck.js slidedeck into PDF:
 

--- a/src/main/resources/ruban.groovy
+++ b/src/main/resources/ruban.groovy
@@ -3,9 +3,26 @@ setup = {
 }
 
 isLastSlide = {
-    js 'ruban.isLastSlide() && ruban.isLastStep()'
+    if (Boolean.valueOf(options.skipSteps)) {
+        js 'ruban.isLastSlide()'
+    }
+    else {
+        js 'ruban.isLastSlide() && ruban.isLastStep()'
+    }
 }
 
 nextSlide = {
-    js 'ruban.next();'
+    if (Boolean.valueOf(options.skipSteps)) {
+        js '''
+            ruban.nextSlide();
+            if (ruban.hasSteps()) {
+                while (!ruban.isLastStep()) {
+                    ruban.next();
+                }
+            }
+        '''
+    }
+    else {
+        js 'ruban.next();'
+    }
 }

--- a/src/main/resources/ruban.groovy
+++ b/src/main/resources/ruban.groovy
@@ -1,0 +1,11 @@
+setup = {
+    js 'ruban.disableTransitions();'
+}
+
+isLastSlide = {
+    js 'ruban.isLastSlide() && ruban.isLastStep()'
+}
+
+nextSlide = {
+    js 'ruban.next();'
+}


### PR DESCRIPTION
This pull request adds two profiles, both for [Ruban](https://github.com/loicfrering/ruban).
An example PDF file generated with the ruban profile, from [the official ruban documentation slides](http://loicfrering.github.io/ruban/), can be viewed at [https://www.dropbox.com/s/nwjnj3i7wiy5jo1/test-ruban.pdf](here).

Why 2 different profiles?

Because ruban slides can have "steps": a single slide can have several steps, shown one after the other. One of the ruban profiles displays each step on a separate PDF page making the result close to what the HTML slide deck looks like. 
The other only displays the final step of each slide, which allows generating shorter PDF documents, without losing content.
